### PR TITLE
Upgrade to use converse API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ CDK を実行するためには、 AWS の Credential を設定する必要が�
 > [!IMPORTANT]
 > 本リポジトリで利用する Anthropic Claude モデルの利用は事前申請が必要です。 [Model access 画面 (ap-northeast-1)](https://ap-northeast-1.console.aws.amazon.com/bedrock/home?region=ap-northeast-1#/modelaccess)を開き、Anthropic Claude Instant にチェックして Save changes してください。利用するリージョンとモデル単位で申請が必要なので、ご注意ください。
 
-デフォルトでは、東京リージョン（`ap-northeast-1`）の `Claude Instant` モデルを利用する設定になっています。もし、利用するリージョンとモデルを変更したい場合は、`packages/cdk/cdk.json` の `bedrock-region` と `bedrock-model-id` を変更してください。
+デフォルトでは、東京リージョン（`ap-northeast-1`）の `Claude Instant` モデルを利用する設定になっています。もし、利用するリージョンとモデルを変更したい場合は、`packages/cdk/cdk.json` の `bedrock-region` と `bedrock-model-id` を変更してください。モデルIDは[こちら](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html)をご参照ください。
 
-**こちらのリポジトリは、`anthropic.claude-instant-v1`、`anthropic.claude-v2`、`anthropic.claude-v2:1` のみ対応しています。他のモデルは利用できませんので、ご注意ください。**
+**こちらのリポジトリは、[Amazon Bedrock Converse API に対応しているモデル](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html)ならばいずれも使用可能です。**
 
 ### デプロイ手順
 

--- a/README_en.md
+++ b/README_en.md
@@ -31,9 +31,9 @@ To execute CDK, it is necessary to set up AWS credentials. Please follow the ste
 > [!IMPORTANT]
 > Prior application is necessary to use the Anthropic Claude model in this repository. Open the [Model access screen (ap-northeast-1)](https://ap-northeast-1.console.aws.amazon.com/bedrock/home?region=ap-northeast-1#/modelaccess), check Anthropic Claude Instant and Save changes. Please note that application is required for each region and model you wish to use.
 
-By default, the `Claude Instant` model in the Tokyo region (`ap-northeast-1`) is set for use. If you wish to change the region and model used, please modify `bedrock-region` and `bedrock-model-id` in `packages/cdk/cdk.json`.
+By default, the `Claude Instant` model in the Tokyo region (`ap-northeast-1`) is set for use. If you wish to change the region and model used, please modify `bedrock-region` and `bedrock-model-id` in `packages/cdk/cdk.json`. Model IDs can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).
 
-**This repository only supports `anthropic.claude-instant-v1`, `anthropic.claude-v2`, and `anthropic.claude-v2:1`. Other models are not supported.**
+**This repository is compatible with any model supported by the [Amazon Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html).**
 
 ### Deployment Steps
 


### PR DESCRIPTION
Using the Converse API enables access to Claude 3, 3.5, and all models supporting the Converse API.

*Issue #, if available:*
resolves #2 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
